### PR TITLE
Fix header color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -4,7 +4,7 @@
   list-style: none;
   a {
     padding: 6px 10px;
-    color: $primary;
+    color: $header_primary;
     font-size: $font-up-1;
   }
 }


### PR DESCRIPTION
Since we're dealing with headers, it makes more sense to set the color as "header_primary" and not "primary".