### PR TITLE
make class name more unique to prevent collisions

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -15,7 +15,7 @@
     const deviceClass = `.${seg[3]}`;
     const linkTarget = seg[4] === "self" ? "" : "_blank";
     const keepOnScrollClass = seg[5] === "keep" ? ".keep" : "";
-    const linkClass = `.${linkText.trim().toLowerCase().replace(/\s/gi, '-')}`;
+    const linkClass = `.${linkText.trim().toLowerCase().replace(/\s/gi, '-')}-custom-header-links`;
 
     if (!linkTarget) {
       headerLinks.push(


### PR DESCRIPTION
naming a nav link "Directory" for instance collides with a core css class name

https://meta.discourse.org/t/custom-header-links/90588/102?u=weallwegot