### PR TITLE
FIX: Links are not displayed if the setting doesn't associate a locale

### DIFF
--- a/javascripts/discourse/initializers/discourse-custom-header-links.js
+++ b/javascripts/discourse/initializers/discourse-custom-header-links.js
@@ -44,7 +44,7 @@ export default {
             .toLowerCase()
             .replace(/\s/gi, "-")}-custom-header-links`;
 
-          const localeClass = locale === "" ? "" : `.${locale}`;
+          const localeClass = locale === undefined ? "" : `.${locale}`;
 
           const anchorAttributes = {
             title: linkTitle,
@@ -55,7 +55,7 @@ export default {
           }
 
           if (
-            locale !== "" &&
+            locale !== undefined &&
             document.documentElement.lang &&
             document.documentElement.lang !== locale
           ) {


### PR DESCRIPTION
Related #30.
Reported here: https://meta.discourse.org/t/missing-custom-header-links-after-update/262594

#### Current behavior
The links are not displayed if a locale is not provided in the setting.

#### Expected behavior
By not associating a locale with a link, the link should be displayed by default.

---

Unpacking a value from `split` that doesn't exist (here `locale`) will return `undefined`.