### PR TITLE
UX: fix compatibility with discourse-header-search

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,3 +1,7 @@
+.before-header-panel-outlet {
+  display: flex;
+}
+
 @if $links_position == "right" {
   .before-header-panel-outlet {
     margin-left: auto;
@@ -37,4 +41,23 @@
 .desktop-view .headerLink--vmo,
 .mobile-view .headerLink--vdo {
   display: none;
+}
+
+// for compatibility with the discourse-header-search component
+
+.floating-search-input-wrapper {
+  flex: 1 1 auto;
+  margin: 0 1em;
+  @if $links_position == "left" {
+    order: 2;
+  }
+
+  .floating-search-input {
+    width: 100%;
+    margin: 0;
+  }
+
+  .search-menu {
+    width: 100% !important; // overrides very specific selector
+  }
 }


### PR DESCRIPTION
This fixes a compatibility issue with the discourse-header-search component (requires this sibling update https://github.com/discourse/discourse-header-search/pull/28)

Before
![Screenshot 2023-08-15 at 11 21 18 AM](https://github.com/discourse/discourse-custom-header-links/assets/1681963/a96d19a1-af30-422c-aa81-d2d6d8df0da8)

After
![Screenshot 2023-08-15 at 11 18 20 AM](https://github.com/discourse/discourse-custom-header-links/assets/1681963/a9b183a8-a42c-459f-aa5a-fde50709d02a)
![Screenshot 2023-08-15 at 11 18 32 AM](https://github.com/discourse/discourse-custom-header-links/assets/1681963/0d672b60-52ee-4a6f-8d46-6dadcc0fc4b9)
