### PR TITLE
UX: remove locale from default settings

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,7 +1,7 @@
 Custom_header_links:
   type: list
   list_type: simple
-  default: "External link, this link will open in a new tab, https://meta.discourse.org, vdo, blank, remove, en|Most Liked, Posts with the most amount of likes, /latest/?order=op_likes, vdo, self, keep, en|Privacy, Our Privacy Policy, /privacy, vdm, self, keep, en"
+  default: "External link, this link will open in a new tab, https://meta.discourse.org, vdo, blank, remove|Most Liked, Posts with the most amount of likes, /latest/?order=op_likes, vdo, self, keep|Privacy, Our Privacy Policy, /privacy, vdm, self, keep"
   description:
     en: "Comma delimited in this order: link text, link title, URL, view, target, hide on scroll<br><b>Link text:</b> The text for the link<br><b>Link title:</b> the text that shows when the link is hovered<br><b>URL:</b> The path for the link (can be relative)<br><b>View:</b> vdm = desktop and mobile, vdo = desktop only, vmo = mobile only<br><b>Target:</b> blank = opens in a new tab, self = opens in the same tab<br><b>Hide on scroll:</b> remove = hides the link when the title is expanded on topic pages keep = keeps the link visible even when the title is visible on topic pages<br><b>Language:</b> blank = no locale assoaciated to the link, else insert a locale code (en, fr, de, ...)"
 


### PR DESCRIPTION
If someone doesn't have their locale set to `en` the default links won't appear on the initial install, which makes the component seem broken. 

This removes the locale from these defaults, so they will appear no matter the site locale. 