### PR TITLE
DEV: Rename `Custom_header_links` settings to `custom_header_links`

### DIFF
--- a/javascripts/discourse/components/custom-header-links.js
+++ b/javascripts/discourse/components/custom-header-links.js
@@ -3,11 +3,11 @@ import { dasherize } from "@ember/string";
 
 export default class CustomHeaderLinks extends Component {
   get shouldShow() {
-    return settings.Custom_header_links?.length > 0;
+    return settings.custom_header_links?.length > 0;
   }
 
   get links() {
-    return settings.Custom_header_links.split("|").reduce((result, item) => {
+    return settings.custom_header_links.split("|").reduce((result, item) => {
       let [
         linkText,
         linkTitle,

--- a/migrations/settings/0001-rename-settings.js
+++ b/migrations/settings/0001-rename-settings.js
@@ -1,0 +1,8 @@
+export default function migrate(settings) {
+  if (settings.has("Custom_header_links")) {
+    settings.set("custom_header_links", settings.get("Custom_header_links"));
+    settings.delete("Custom_header_links");
+  }
+
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -1,4 +1,4 @@
-Custom_header_links:
+custom_header_links:
   type: list
   list_type: simple
   default: "External link, this link will open in a new tab, https://meta.discourse.org, vdo, blank, remove|Most Liked, Posts with the most amount of likes, /latest/?order=op_likes, vdo, self, keep|Privacy, Our Privacy Policy, /privacy, vdm, self, keep"

--- a/test/unit/migrations/settings/0001-rename-settings-test.js
+++ b/test/unit/migrations/settings/0001-rename-settings-test.js
@@ -1,0 +1,25 @@
+import { module, test } from "qunit";
+import migrate from "../../../../migrations/settings/0001-rename-settings";
+
+module("Unit | Migrations | Settings | 0001-rename-settings", function () {
+  test("migrate", function (assert) {
+    const settings = new Map(
+      Object.entries({
+        Custom_header_links: "some,links",
+      })
+    );
+
+    const result = migrate(settings);
+
+    assert.deepEqual(
+      Array.from(result),
+      Array.from(
+        new Map(
+          Object.entries({
+            custom_header_links: "some,links",
+          })
+        )
+      )
+    );
+  });
+});


### PR DESCRIPTION
Why this change?

Using uppercase in settings name is not part of our convention so renaming it here.