### PR TITLE
DEV: Move setting translation to locale files instead.

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,5 @@
+en:
+  theme_metadata:
+    settings:
+      custom_header_links: "Comma delimited in this order: link text, link title, URL, view, target, hide on scroll<br><b>Link text:</b> The text for the link<br><b>Link title:</b> the text that shows when the link is hovered<br><b>URL:</b> The path for the link (can be relative)<br><b>View:</b> vdm = desktop and mobile, vdo = desktop only, vmo = mobile only<br><b>Target:</b> blank = opens in a new tab, self = opens in the same tab<br><b>Hide on scroll:</b> remove = hides the link when the title is expanded on topic pages keep = keeps the link visible even when the title is visible on topic pages<br><b>Language:</b> blank = no locale assoaciated to the link, else insert a locale code (en, fr, de, ...)"
+      links_position: "Note that when links are displayed on the left, they're automatically hidden while scrolling within topics to make room for the title"

--- a/settings.yml
+++ b/settings.yml
@@ -2,8 +2,6 @@ custom_header_links:
   type: list
   list_type: simple
   default: "External link, this link will open in a new tab, https://meta.discourse.org, vdo, blank, remove|Most Liked, Posts with the most amount of likes, /latest/?order=op_likes, vdo, self, keep|Privacy, Our Privacy Policy, /privacy, vdm, self, keep"
-  description:
-    en: "Comma delimited in this order: link text, link title, URL, view, target, hide on scroll<br><b>Link text:</b> The text for the link<br><b>Link title:</b> the text that shows when the link is hovered<br><b>URL:</b> The path for the link (can be relative)<br><b>View:</b> vdm = desktop and mobile, vdo = desktop only, vmo = mobile only<br><b>Target:</b> blank = opens in a new tab, self = opens in the same tab<br><b>Hide on scroll:</b> remove = hides the link when the title is expanded on topic pages keep = keeps the link visible even when the title is visible on topic pages<br><b>Language:</b> blank = no locale assoaciated to the link, else insert a locale code (en, fr, de, ...)"
 
 links_position:
   default: right
@@ -11,5 +9,3 @@ links_position:
   choices:
     - right
     - left
-  description:
-    en: "Note that when links are displayed on the left, they're automatically hidden while scrolling within topics to make room for the title"


### PR DESCRIPTION
Why this change?

This is the recommended way to add descriptions for a theme setting as
mixing translation for multiple locales in the settings file is not
recommended per
https://meta.discourse.org/t/add-localizable-strings-to-themes-and-theme-components/109867.
