### PR TITLE
FIX: Allow title to be blank when migrating `custom_header_links`

### DIFF
--- a/migrations/settings/0002-migrate-custom-header-links.js
+++ b/migrations/settings/0002-migrate-custom-header-links.js
@@ -16,12 +16,15 @@ export default function migrate(settings) {
         .split(",")
         .map((s) => s.trim());
 
-      if (text && title && url) {
+      if (text && url) {
         const newLink = {
           text,
-          title,
           url,
         };
+
+        if (title) {
+          newLink.title = title;
+        }
 
         if (["vdm", "vdo", "vmo"].includes(view)) {
           newLink.view = view;

--- a/test/unit/migrations/settings/0002-migrate-custom-header-links-test.js
+++ b/test/unit/migrations/settings/0002-migrate-custom-header-links-test.js
@@ -156,6 +156,35 @@ module(
       );
     });
 
+    test("migrate when title is not provided", function (assert) {
+      const settings = new Map(
+        Object.entries({
+          custom_header_links: "External link, , https://meta.discourse.org",
+        })
+      );
+
+      const result = migrate(settings);
+
+      const expectedResult = new Map(
+        Object.entries({
+          custom_header_links: [
+            {
+              text: "External link",
+              url: "https://meta.discourse.org",
+              view: "vdm",
+              target: "blank",
+              hide_on_scroll: "keep",
+            },
+          ],
+        })
+      );
+
+      assert.deepEqual(
+        Object.fromEntries(result.entries()),
+        Object.fromEntries(expectedResult.entries())
+      );
+    });
+
     test("migrate", function (assert) {
       const settings = new Map(
         Object.entries({


### PR DESCRIPTION
This commit allows setting value of `Link Name, ,/some/path` to be migrated. This format of the setting was allowed and the current migration will not migrate the link if the title is empty which isn't what we want.

Follows-up to 167bc8cee96ca7f7b140682ffca3aa5425846ca2