### PR TITLE
DEV: Fix custom_header_links migration to handle blank string

### DIFF
--- a/migrations/settings/0002-migrate-custom-header-links.js
+++ b/migrations/settings/0002-migrate-custom-header-links.js
@@ -8,7 +8,7 @@ export default function migrate(settings) {
     return settings;
   }
 
-  if (oldSetting) {
+  if (typeof oldSetting === "string") {
     const newLinks = [];
 
     oldSetting.split("|").forEach((link) => {

--- a/test/unit/migrations/settings/0002-migrate-custom-header-links-test.js
+++ b/test/unit/migrations/settings/0002-migrate-custom-header-links-test.js
@@ -43,6 +43,21 @@ module(
       );
     });
 
+    test("migrate when old setting value is an empty string", function (assert) {
+      const settings = new Map(Object.entries({ custom_header_links: "" }));
+
+      const result = migrate(settings);
+
+      const expectedResult = new Map(
+        Object.entries({ custom_header_links: [] })
+      );
+
+      assert.deepEqual(
+        Object.fromEntries(result.entries()),
+        Object.fromEntries(expectedResult.entries())
+      );
+    });
+
     test("migrate when old setting value is invalid", function (assert) {
       const settings = new Map(
         Object.entries({


### PR DESCRIPTION
If the old theme setting value is set to a blank string, we will end up not migrating it and thus cause an error to be raised.