### PR TITLE
UX: normalize locale

### DIFF
--- a/javascripts/discourse/components/custom-header-links.js
+++ b/javascripts/discourse/components/custom-header-links.js
@@ -2,7 +2,7 @@ import Component from "@glimmer/component";
 import { dasherize } from "@ember/string";
 
 function normalizeLocale(locale) {
-  return locale?.toLowerCase().replace(/-/g, "_");
+  return locale?.trim().toLowerCase().replace(/[-_]/g, "_");
 }
 export default class CustomHeaderLinks extends Component {
   get shouldShow() {

--- a/javascripts/discourse/components/custom-header-links.js
+++ b/javascripts/discourse/components/custom-header-links.js
@@ -1,6 +1,9 @@
 import Component from "@glimmer/component";
 import { dasherize } from "@ember/string";
 
+function normalizeLocale(locale) {
+  return locale?.toLowerCase().replace(/-/g, "_");
+}
 export default class CustomHeaderLinks extends Component {
   get shouldShow() {
     return settings.custom_header_links?.length > 0;
@@ -16,7 +19,9 @@ export default class CustomHeaderLinks extends Component {
       const locale = link.locale;
       const device = link.view;
 
-      if (!linkText || (locale && document.documentElement.lang !== locale)) {
+      const currentLocale = normalizeLocale(document.documentElement.lang);
+
+      if (!linkText || (locale && normalizeLocale(locale) !== currentLocale)) {
         return result;
       }
 


### PR DESCRIPTION
We weren't normalizing the locale, so if you're trying to use zh_CN you're not going to get a match for zh-CN 

After this change we should cover common capitalization and dash/underscore variations 

Reported here: https://meta.discourse.org/t/custom-header-link-locale-is-not-working-for-some-languages/365933