### PR TITLE
UX: prevent padding wrapping on small screens

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -29,6 +29,8 @@
     list-style: none;
 
     a {
+      display: flex;
+      gap: var(--space-1);
       padding: 0.35em 0.6em;
       color: var(--header_primary);
       font-size: var(--font-up-1);


### PR DESCRIPTION
The display type can cause the padding to wrap, which breaks alignment. Switching to flex prevents this. 


Before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e8458524-8754-4f29-acfb-31e356152935" />


After:
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/f0181a7d-6b35-4fce-86a7-ad7d2d320589" />

